### PR TITLE
src : closedir function could modify the return type to void

### DIFF
--- a/src/vmsdir.h
+++ b/src/vmsdir.h
@@ -70,7 +70,7 @@ typedef struct DIR
 
 DIR *opendir ();
 struct direct *readdir (DIR *dfd);
-int closedir (DIR *dfd);
+void closedir (DIR *dfd);
 const char *vmsify (const char *name, int type);
 
 #endif /* VMSDIR_H */

--- a/src/vmsfunctions.c
+++ b/src/vmsfunctions.c
@@ -110,7 +110,7 @@ readdir (DIR *dir)
   return (dentry);
 }
 
-int
+void
 closedir (DIR *dir)
 {
   if (dir != NULL)
@@ -122,8 +122,6 @@ closedir (DIR *dir)
       free (dnam);
       free (dir);
     }
-
-  return 0;
 }
 #endif /* compiled for OpenVMS prior to V7.x */
 


### PR DESCRIPTION
This function remains consistent.